### PR TITLE
Update module manifest for Foundry v13

### DIFF
--- a/module/module.json
+++ b/module/module.json
@@ -1,5 +1,5 @@
 {
-  "name": "pf2e-combat-log",
+  "id": "pf2e-combat-log",
   "title": "PF2e Combat Log",
   "description": "Adds a combat log for Pathfinder 2E in Foundry VTT.",
   "version": "0.1.0",
@@ -9,8 +9,19 @@
   "esmodules": ["scripts/main.js"],
   "packs": [],
   "languages": [],
+  "manifestPlusVersion": "1.2.0",
+  "url": "https://github.com/user/PF2e-Combat-Log",
+  "manifest": "https://github.com/user/PF2e-Combat-Log/releases/latest/download/module.json",
+  "manifest+": "https://github.com/user/PF2e-Combat-Log/releases/latest/download/module.json",
+  "download": "https://github.com/user/PF2e-Combat-Log/releases/latest/download/module.zip",
+  "relationships": {
+    "systems": [
+      { "id": "pf2e" }
+    ],
+    "requires": []
+  },
   "compatibility": {
-    "minimum": "10",
-    "verified": "10"
+    "minimum": "13",
+    "verified": "13"
   }
 }


### PR DESCRIPTION
## Summary
- Adopt Foundry v13 manifest schema with `id`, manifest links, and system relationships
- Require Foundry v13 by setting compatibility minimum and verified versions to 13

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b586f41ce8832798f04e91535fe819