### PR TITLE
feat: enrich combat encounter logs

### DIFF
--- a/module/scripts/main.js
+++ b/module/scripts/main.js
@@ -37,24 +37,56 @@ Hooks.on("createChatMessage", (message, context, userId) => {
   console.log("PF2e Combat Log | Chat message created:", message);
 });
 
+async function updateIndexPage(journal) {
+  const indexName = "Encounter Index";
+  let indexPage = journal.pages.find((p) => p.name === indexName);
+  const links = journal.pages
+    .filter((p) => p.name !== indexName)
+    .sort((a, b) => b.name.localeCompare(a.name))
+    .map((p) => `- @UUID[${p.uuid}]{${p.name}}`)
+    .join("\n");
+  const content = `## Encounters\n${links}`;
+  if (!indexPage) {
+    await journal.createEmbeddedDocuments("JournalEntryPage", [
+      {
+        name: indexName,
+        type: "text",
+        text: {
+          content,
+          format: CONST.JOURNAL_ENTRY_PAGE_FORMATS.MARKDOWN,
+        },
+      },
+    ]);
+  } else {
+    await indexPage.update({
+      text: {
+        content,
+        format: CONST.JOURNAL_ENTRY_PAGE_FORMATS.MARKDOWN,
+      },
+    });
+  }
+}
+
 async function logCombat(combat) {
   if (!combatLogJournalId) return;
   const journal = game.journal.get(combatLogJournalId);
   if (!journal) return;
 
+  const timestamp = new Date().toLocaleString();
   const rows = combat.combatants
-    .map(
-      (c) =>
-        `| ${c.token?.uuid ?? c.actor?.uuid ?? c.uuid} | ${c.initiative ?? ""} |`
-    )
+    .map((c) => {
+      const uuid = c.token?.uuid ?? c.actor?.uuid ?? c.uuid;
+      const name = c.token?.name ?? c.actor?.name ?? c.name ?? uuid;
+      return `| @UUID[${uuid}]{${name}} | ${c.initiative ?? ""} |`;
+    })
     .join("\n");
   const chatLog = combatMessages.map((m) => `> ${m}`).join("\n");
   const content =
-    `| Combatant | Initiative |\n| --- | --- |\n${rows}` +
+    `<h2>${timestamp}</h2>\n\n| Combatant | Initiative |\n| --- | --- |\n${rows}` +
     (chatLog ? `\n\n### Chat Log\n${chatLog}` : "");
   await journal.createEmbeddedDocuments("JournalEntryPage", [
     {
-      name: new Date().toLocaleString(),
+      name: timestamp,
       type: "text",
       text: {
         content,
@@ -62,6 +94,9 @@ async function logCombat(combat) {
       },
     },
   ]);
+
+  await updateIndexPage(journal);
+
   combatMessages = [];
 }
 


### PR DESCRIPTION
## Summary
- include timestamp headers, combatant links, and chat logs in each encounter entry
- maintain an index page linking to past encounters for quick navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b589e5a2808327b028c2dc25a19b47