### PR TITLE
fix: support v11 combat tracker

### DIFF
--- a/module/scripts/main.js
+++ b/module/scripts/main.js
@@ -53,10 +53,15 @@ Hooks.on("createChatMessage", (message, context, userId) => {
 });
 
 function getSelectedCombats() {
-  const ids = ui.combat?.element
-    .find("li.combat[data-combat-id].active, li.combat[data-combat-id].expanded")
-    .map((_, el) => el.dataset.combatId)
-    .toArray();
+  // In Foundry V11 `ui.combat.element` is a regular DOM element instead of a
+  // jQuery object. Use `querySelectorAll` and `Array.from` to collect the
+  // selected combat IDs in a version‑agnostic way.
+  const ids = Array.from(
+    ui.combat?.element.querySelectorAll(
+      "li.combat[data-combat-id].active, li.combat[data-combat-id].expanded"
+    ) ?? []
+  ).map((el) => el.dataset.combatId);
+
   if (ids.length === 0) {
     return game.combat ? [game.combat] : [];
   }


### PR DESCRIPTION
## Summary
- replace jQuery-based combat selection with querySelectorAll for Foundry V11 compatibility

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ce098ac83278b86db13bc6ee836