### PR TITLE
Fix combat log heading markdown

### DIFF
--- a/module/scripts/main.js
+++ b/module/scripts/main.js
@@ -126,7 +126,7 @@ async function logCombat(combat, messages) {
     .join("\n");
   const chatLog = messages.map((m) => `> ${m.content ?? m}`).join("\n");
   const content =
-    `<h2>${timestamp}</h2>\n\n| Combatant | Initiative |\n| --- | --- |\n${rows}` +
+    `## ${timestamp}\n\n| Combatant | Initiative |\n| --- | --- |\n${rows}` +
     (chatLog ? `\n\n### Chat Log\n${chatLog}` : "");
   await journal.createEmbeddedDocuments("JournalEntryPage", [
     {


### PR DESCRIPTION
## Summary
- use Markdown heading for combat log entry pages instead of HTML

## Testing
- `npm test` *(fails: ENOENT package.json)*
- manual: verified generated markdown string contains combatant table and chat log

------
https://chatgpt.com/codex/tasks/task_e_68b5a10da5048327bbe03e5295b60586