### PR TITLE
Handle markdown journal page content correctly

### DIFF
--- a/module/scripts/main.js
+++ b/module/scripts/main.js
@@ -94,16 +94,16 @@ async function updateIndexPage(journal) {
         name: indexName,
         type: "text",
         text: {
-          content,
           format: CONST.JOURNAL_ENTRY_PAGE_FORMATS.MARKDOWN,
+          markdown: content,
         },
       },
     ]);
   } else {
     await indexPage.update({
       text: {
-        content,
         format: CONST.JOURNAL_ENTRY_PAGE_FORMATS.MARKDOWN,
+        markdown: content,
       },
     });
   }
@@ -133,8 +133,8 @@ async function logCombat(combat, messages) {
       name: timestamp,
       type: "text",
       text: {
-        content,
         format: CONST.JOURNAL_ENTRY_PAGE_FORMATS.MARKDOWN,
+        markdown: content,
       },
     },
   ]);


### PR DESCRIPTION
## Summary
- Ensure journal pages store markdown in `text.markdown`
- Update encounter index to use `markdown` field as well

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a4c8d5f88327a57f7ecc25c96f4d