### PR TITLE
Include flavor text in combat log

### DIFF
--- a/module/scripts/main.js
+++ b/module/scripts/main.js
@@ -124,7 +124,12 @@ async function logCombat(combat, messages) {
       return `| @UUID[${uuid}]{${name}} | ${c.initiative ?? ""} |`;
     })
     .join("\n");
-  const chatLog = messages.map((m) => `> ${m.content ?? m}`).join("\n");
+  const chatLog = messages
+    .map((m) => {
+      const flavor = m.flavor ? `${m.flavor}: ` : "";
+      return `> ${flavor}${m.content ?? ""}`;
+    })
+    .join("\n");
   const content =
     `## ${timestamp}\n\n| Combatant | Initiative |\n| --- | --- |\n${rows}` +
     (chatLog ? `\n\n### Chat Log\n${chatLog}` : "");


### PR DESCRIPTION
## Summary
- Use both `message.flavor` and `message.content` when recording chat log entries so attack descriptions appear alongside roll results

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b5a839ed3c8327967f1c78f98060fb