### PR TITLE
Prefix chat log entries with speaker names

### DIFF
--- a/module/scripts/main.js
+++ b/module/scripts/main.js
@@ -126,8 +126,9 @@ async function logCombat(combat, messages) {
     .join("\n");
   const chatLog = messages
     .map((m) => {
+      const actor = m.alias ?? m.speaker?.alias ?? "";
       const flavor = m.flavor ? `${m.flavor}: ` : "";
-      return `> ${flavor}${m.content ?? ""}`;
+      return `> ${actor ? `${actor}: ` : ""}${flavor}${m.content ?? ""}`;
     })
     .join("\n");
   const content =


### PR DESCRIPTION
## Summary
- prefix exported chat log entries with the actor name while retaining existing flavor and content

## Testing
- `node --check module/scripts/main.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aa56f2148327a3c10d2fe9c54c4f