### PR TITLE
Use actor portrait for avatar download

### DIFF
--- a/module/scripts/main.js
+++ b/module/scripts/main.js
@@ -40,7 +40,7 @@ Hooks.on("chatMessage", (chatLog, message, chatData) => {
     }
     return false;
   }
-  if (message.startsWith("/downloadavatar")) {
+  if (message.startsWith("/downloadportrait")) {
     downloadSelectedTokenAvatar();
     return false;
   }
@@ -89,9 +89,13 @@ async function downloadSelectedTokenAvatar() {
     ui.notifications.warn("No token selected.");
     return;
   }
-  const src = token.document?.texture?.src;
+  if (!token.actor) {
+    ui.notifications.error("Token has no actor.");
+    return;
+  }
+  const src = token.actor?.img;
   if (!src) {
-    ui.notifications.error("Token has no image.");
+    ui.notifications.error("Actor has no image.");
     return;
   }
   try {
@@ -100,7 +104,7 @@ async function downloadSelectedTokenAvatar() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = src.split("/").pop() || "avatar";
+    a.download = src.split("/").pop() || "portrait";
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);


### PR DESCRIPTION
## Summary
- Use the actor's portrait instead of the token texture when downloading the selected token's image
- Rename chat command to `/downloadportrait`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b689f794948327a928246c3553ab32